### PR TITLE
disable introspect

### DIFF
--- a/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py
+++ b/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py
@@ -43,7 +43,7 @@ class DiagnosticsCharacteristic(Characteristic):
         logger.debug('Diagnostics miner_bus')
         miner_bus = dbus.SystemBus()
         logger.debug('Diagnostics miner_object')
-        miner_object = miner_bus.get_object('com.helium.Miner', '/')
+        miner_object = miner_bus.get_object('com.helium.Miner', '/', introspect=False)
         logger.debug('Diagnostics miner_interface')
         miner_interface = dbus.Interface(miner_object, 'com.helium.Miner')
         logger.debug('Diagnostics p2pstatus')


### PR DESCRIPTION
**Why**
Now we see all the internal logs of the dbus library. And all internal errors that we see are logged by the sentry.

**How**
Disable introspect for object.

**References**
[dbus docs](https://dbus.freedesktop.org/doc/dbus-python/dbus.bus.html#dbus.bus.BusConnection.get_object)

closes #31 

output before:
```
 gateway-config  2021-09-29 11:00:58,023 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).ReadValue -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(32) - Read diagnostics
 gateway-config  DEBUG:gatewayconfig.bluetooth.characteristics.diagnostics_characteristic:Read diagnostics
 gateway-config  2021-09-29 11:00:58,025 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).get_p2pstatus -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(43) - Diagnostics miner_bus
 gateway-config  DEBUG:gatewayconfig.bluetooth.characteristics.diagnostics_characteristic:Diagnostics miner_bus
 gateway-config  2021-09-29 11:00:58,026 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).get_p2pstatus -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(45) - Diagnostics miner_object
 gateway-config  DEBUG:gatewayconfig.bluetooth.characteristics.diagnostics_characteristic:Diagnostics miner_object
 gateway-config  2021-09-29 11:00:58,029 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).get_p2pstatus -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(47) - Diagnostics miner_interface
 gateway-config  DEBUG:gatewayconfig.bluetooth.characteristics.diagnostics_characteristic:Diagnostics miner_interface
 gateway-config  2021-09-29 11:00:58,030 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).get_p2pstatus -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(49) - Diagnostics p2pstatus
 gateway-config  DEBUG:gatewayconfig.bluetooth.characteristics.diagnostics_characteristic:Diagnostics p2pstatus
 gateway-config  ERROR:dbus.proxies:Introspect error on :1.93:/: dbus.exceptions.DBusException: org.freedesktop.DBus.Error.NotSupported: org.freedesktop.DBus.Introspectable.Introspect
 gateway-config  2021-09-29 11:00:59,983 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).get_p2pstatus -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(53) - DBUS P2P SUCCEED
 gateway-config  DEBUG:gatewayconfig.bluetooth.characteristics.diagnostics_characteristic:DBUS P2P SUCCEED
 gateway-config  2021-09-29 11:00:59,984 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).get_p2pstatus -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(54) - dbus.Array([dbus.Struct((dbus.String('connected'), dbus.String('yes')), signature=None), dbus.Struct((dbus.String('dialable'), dbus.String('yes')), signature=None), dbus.Struct((dbus.String('nat_type'), dbus.String('none')), signature=None), dbus.Struct((dbus.String('height'), dbus.String('1029819')), signature=None)], signature=dbus.Signature('(ss)'))
 gateway-config  DEBUG:gatewayconfig.bluetooth.characteristics.diagnostics_characteristic:dbus.Array([dbus.Struct((dbus.String('connected'), dbus.String('yes')), signature=None), dbus.Struct((dbus.String('dialable'), dbus.String('yes')), signature=None), dbus.Struct((dbus.String('nat_type'), dbus.String('none')), signature=None), dbus.Struct((dbus.String('height'), dbus.String('1029819')), signature=None)], signature=dbus.Signature('(ss)'))
 gateway-config  2021-09-29 11:00:59,986 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).get_p2pstatus -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(59) - p2pstatus: dbus.Array([dbus.Struct((dbus.String('connected'), dbus.String('yes')), signature=None), dbus.Struct((dbus.String('dialable'), dbus.String('yes')), signature=None), dbus.Struct((dbus.String('nat_type'), dbus.String('none')), signature=None), dbus.Struct((dbus.String('height'), dbus.String('1029820')), signature=None)], signature=dbus.Signature('(ss)'))
 gateway-config  DEBUG:gatewayconfig.bluetooth.characteristics.diagnostics_characteristic:p2pstatus: dbus.Array([dbus.Struct((dbus.String('connected'), dbus.String('yes')), signature=None), dbus.Struct((dbus.String('dialable'), dbus.String('yes')), signature=None), dbus.Struct((dbus.String('nat_type'), dbus.String('none')), signature=None), dbus.Struct((dbus.String('height'), dbus.String('1029820')), signature=None)], signature=dbus.Signature('(ss)'))
 gateway-config  2021-09-29 11:01:00,482 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).get_ip -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(97) - Using ETH IP address 192.168.0.108
 gateway-config  DEBUG:gatewayconfig.bluetooth.characteristics.diagnostics_characteristic:Using ETH IP address 192.168.0.108
 gateway-config  2021-09-29 11:01:00,484 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).build_diagnostics_proto -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(80) - All attibutes were added to the diagnostics proto
 gateway-config  DEBUG:gatewayconfig.bluetooth.characteristics.diagnostics_characteristic:All attibutes were added to the diagnostics proto
 gateway-config  2021-09-29 11:01:00,487 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).ReadValue -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(36) - Diagnostics are b'\n\x10\n\tconnected\x12\x03yes\n\x0f\n\x08dialable\x12\x03yes\n\x11\n\x06height\x12\x071029820\n\x10\n\x08nat_type\x12\x04none\n\x13\n\x03eth\x12\x0cF04CD503847C\n\x14\n\x04wifi\x12\x0c20F5439B9FB6\n\x12\n\x02fw\x12\x0c2021.09.14.0\n\x13\n\x02ip\x12\r192.168.0.108'
 gateway-config  DEBUG:gatewayconfig.bluetooth.characteristics.diagnostics_characteristic:Diagnostics are b'\n\x10\n\tconnected\x12\x03yes\n\x0f\n\x08dialable\x12\x03yes\n\x11\n\x06height\x12\x071029820\n\x10\n\x08nat_type\x12\x04none\n\x13\n\x03eth\x12\x0cF04CD503847C\n\x14\n\x04wifi\x12\x0c20F5439B9FB6\n\x12\n\x02fw\x12\x0c2021.09.14.0\n\x13\n\x02ip\x12\r192.168.0.108'

```
output after:
```
 gateway-config  2021-09-29 10:45:19,177 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).ReadValue -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(31) - Read diagnostics
 gateway-config  2021-09-29 10:45:19,178 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).get_p2pstatus -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(42) - Diagnostics miner_bus
 gateway-config  2021-09-29 10:45:19,179 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).get_p2pstatus -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(44) - Diagnostics miner_object
 gateway-config  2021-09-29 10:45:19,182 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).get_p2pstatus -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(46) - Diagnostics miner_interface
 gateway-config  2021-09-29 10:45:19,183 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).get_p2pstatus -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(48) - Diagnostics p2pstatus
 gateway-config  2021-09-29 10:45:19,890 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).get_p2pstatus -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(52) - DBUS P2P SUCCEED
 gateway-config  2021-09-29 10:45:19,891 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).get_p2pstatus -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(53) - dbus.Array([dbus.Struct((dbus.String('connected'), dbus.String('yes')), signature=None), dbus.Struct((dbus.String('dialable'), dbus.String('yes')), signature=None), dbus.Struct((dbus.String('nat_type'), dbus.String('none')), signature=None), dbus.Struct((dbus.String('height'), dbus.String('1029808')), signature=None)], signature=dbus.Signature('(ss)'))
 gateway-config  2021-09-29 10:45:19,892 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).get_p2pstatus -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(58) - p2pstatus: dbus.Array([dbus.Struct((dbus.String('connected'), dbus.String('yes')), signature=None), dbus.Struct((dbus.String('dialable'), dbus.String('yes')), signature=None), dbus.Struct((dbus.String('nat_type'), dbus.String('none')), signature=None), dbus.Struct((dbus.String('height'), dbus.String('1029809')), signature=None)], signature=dbus.Signature('(ss)'))
 gateway-config  2021-09-29 10:45:20,328 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).get_ip -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(96) - Using ETH IP address 192.168.0.108
 gateway-config  2021-09-29 10:45:20,329 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).build_diagnostics_proto -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(79) - All attibutes were added to the diagnostics proto
 gateway-config  2021-09-29 10:45:20,332 - [DEBUG] - gatewayconfig.bluetooth.characteristics.diagnostics_characteristic - (diagnostics_characteristic.py).ReadValue -- /opt/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py:(35) - Diagnostics are b'\n\x10\n\tconnected\x12\x03yes\n\x0f\n\x08dialable\x12\x03yes\n\x11\n\x06height\x12\x071029809\n\x10\n\x08nat_type\x12\x04none\n\x13\n\x03eth\x12\x0cF04CD503847C\n\x14\n\x04wifi\x12\x0c20F5439B9FB6\n\x12\n\x02fw\x12\x0c2021.09.14.0\n\x13\n\x02ip\x12\r192.168.0.108'
```