### PR TITLE
Fix bluetooth beacon time

### DIFF
--- a/start-gateway-config.sh
+++ b/start-gateway-config.sh
@@ -14,8 +14,8 @@
 # Advertise on channels 37, 38 and 39
 echo 7 > /sys/kernel/debug/bluetooth/hci0/adv_channel_map
 # Send a beacon every 152.5 ms
-echo 153 > /sys/kernel/debug/bluetooth/hci0/adv_min_interval
-echo 153 > /sys/kernel/debug/bluetooth/hci0/adv_max_interval
+echo 244 > /sys/kernel/debug/bluetooth/hci0/adv_min_interval
+echo 244 > /sys/kernel/debug/bluetooth/hci0/adv_max_interval
 
 # Disable pairing
 


### PR DESCRIPTION
Bluetooth beacon time is 0.625s x value so we are currently using advertising interval of 153 * 0.625 = 95.625 msec

This changes it to the correct value of 152.5 as specified in apple accessory design guidelines https://developer.apple.com/accessories/Accessory-Design-Guidelines.pdf (page 153, section 37.5)
https://www.bluetooth.com/blog/periodic-advertising-sync-transfer/
**Why**
<!-- What is the objective of this work? -->

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->