### PR TITLE
fix: copy build ARG correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ FROM balenalib/raspberry-pi-debian:buster-build-20210705 as builder
 # Nebra uses /opt by convention
 WORKDIR /opt/
 
+# Copy build ARG
+ARG SYSTEM_TIMEZONE
+
 # Copy python dependencies for `pip install` later
 COPY requirements.txt requirements.txt
 
@@ -51,6 +54,9 @@ RUN \
 ################################### Stage: runner ##################################################
 
 FROM balenalib/raspberry-pi-debian-python:buster-run-20210705 as runner
+
+# Copy build ARG
+ARG SYSTEM_TIMEZONE
 
 # Install bluez, libdbus, network-manager, python3-gi, and venv
 RUN \


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

Currently in the build this still shows as $SYSTEM_TIMEZONE in the output instead of the actual value. This is a fix

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

Restate ARG in correct places

**References**
<!-- Links to related issues, relevant documentation, etc. -->