### PR TITLE
fix: get correct ip for wifi

### DIFF
--- a/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py
+++ b/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py
@@ -99,7 +99,7 @@ class DiagnosticsCharacteristic(Characteristic):
         if('eth_ip' in locals()):
             logger.debug("Using ETH IP address %s" % eth_ip)
             ip_address = str(eth_ip)
-        elif('wlanIP' in locals()):
+        elif('wlan_ip' in locals()):
             ip_address = str(wlan_ip)
             logger.debug("Using WLAN IP address %s" % wlan_ip)
         return ip_address


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->
wifi showing 0.0.0.0 IP

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

get ip for wifi by renaming to correct variable

**References**
<!-- Links to related issues, relevant documentation, etc. -->

Closes: #102