### PR TITLE
fix: add wget to runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ RUN \
     TZ="$SYSTEM_TIMEZONE" \
     apt-get install -y \
         bluez=5.50-1.2~deb10u2+rpt1 \
+        wget=1.20.1-1.1 \
         libdbus-1-3=1.12.20-0+deb10u1 \
         network-manager=1.14.6-2+deb10u1 \
         python3-gi=3.30.4-1 \


### PR DESCRIPTION

**Why**
<!-- What is the objective of this work? -->

The check for diagnostics container in #113 is failing to ever be successful due to wget not being installed on the runner

Once #114 is solved we can remove wget from the runner again most likely

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

Add wget to runner

**References**
<!-- Links to related issues, relevant documentation, etc. -->

Closes: #117 