### PR TITLE
fix: use get_public_keys_rust correctly

### DIFF
--- a/gatewayconfig/gatewayconfig_shared_state.py
+++ b/gatewayconfig/gatewayconfig_shared_state.py
@@ -30,6 +30,6 @@ class GatewayconfigSharedState:
 
         try:
             public_keys = get_public_keys_rust()
-            self.public_key = public_keys['PK']
+            self.public_key = public_keys['key']
         except Exception:
             LOGGER.exception("Unable to read public key.")

--- a/tests/gatewayconfig/test_gatewayconfig_shared_state.py
+++ b/tests/gatewayconfig/test_gatewayconfig_shared_state.py
@@ -19,13 +19,13 @@ class TestGatewayconfigSha(TestCase):
         self.assertEqual(shared_state.to_s(), 
             '{"wifi_list_cache": [], "should_scan_wifi": false, "should_advertise_bluetooth": true, "is_advertising_bluetooth": false, "are_diagnostics_ok": false, "public_key": "Unavailable"}') 
     
-    @patch('gatewayconfig.gatewayconfig_shared_state.get_public_keys_rust', return_value={'PK': 'foo'})
+    @patch('gatewayconfig.gatewayconfig_shared_state.get_public_keys_rust', return_value={'key': 'foo'})
     def test_load_public_key(self, _):
         shared_state = GatewayconfigSharedState()
         shared_state.load_public_key()
         self.assertEqual(shared_state.public_key, 'foo')
 
-    @patch('gatewayconfig.gatewayconfig_shared_state.get_public_keys_rust', return_value={'PK': 'foo'})
+    @patch('gatewayconfig.gatewayconfig_shared_state.get_public_keys_rust', return_value={'key': 'foo'})
     def test_load_public_key_dont_override(self, _):
         shared_state = GatewayconfigSharedState()
         shared_state.public_key = 'already_set'


### PR DESCRIPTION
**Why**
As a hotspot owner, I want to be able to access my public key.

**How**
Response has 'key' not 'PK'

**References**

- Fixes: https://github.com/NebraLtd/hm-config/pull/142