### PR TITLE
fix: add error message when no BT device

### DIFF
--- a/lib/cputemp/advertisement.py
+++ b/lib/cputemp/advertisement.py
@@ -22,8 +22,10 @@ SOFTWARE.
 
 import dbus
 import dbus.service
-
+from hm_pyhelper.logger import get_logger
 from lib.cputemp.bletools import BleTools
+
+logger = get_logger(__name__)
 
 BLUEZ_SERVICE_NAME = "org.bluez"
 LE_ADVERTISING_MANAGER_IFACE = "org.bluez.LEAdvertisingManager1"
@@ -134,12 +136,21 @@ class Advertisement(dbus.service.Object):
     def register(self):
         bus = BleTools.get_bus()
         adapter = BleTools.find_adapter(bus)
+        if not adapter:
+            logger.error(
+                "Unable to start Advertisement: No Bluetooth adapter.")
+            return
 
         ad_manager = dbus.Interface(
             bus.get_object(
                 BLUEZ_SERVICE_NAME,
                 adapter),
             LE_ADVERTISING_MANAGER_IFACE)
+        if not ad_manager:
+            logger.error("Unable to start Advertisement: "
+                         "No Bluetooth Advertising Manager.")
+            return
+
         ad_manager.RegisterAdvertisement(
             self.get_path(),
             {},

--- a/lib/cputemp/service.py
+++ b/lib/cputemp/service.py
@@ -23,15 +23,17 @@ import dbus
 import dbus.service
 import dbus.mainloop.glib
 import dbus.exceptions
-
 import array
+from hm_pyhelper.logger import get_logger
+from lib.cputemp.bletools import BleTools
+
+logger = get_logger(__name__)
 
 try:
     from gi.repository import GObject
 except ImportError:
     import gobject as GObject
 
-from lib.cputemp.bletools import BleTools
 
 BLUEZ_SERVICE_NAME = "org.bluez"
 GATT_MANAGER_IFACE = "org.bluez.GattManager1"
@@ -93,10 +95,17 @@ class Application(dbus.service.Object):
 
     def register(self):
         adapter = BleTools.find_adapter(self.bus)
+        if not adapter:
+            logger.error(
+                "Unable to start Bluetooth application: No Bluetooth Adapter")
+            return
 
         service_manager = dbus.Interface(
                 self.bus.get_object(BLUEZ_SERVICE_NAME, adapter),
                 GATT_MANAGER_IFACE)
+        if not service_manager:
+            logger.error("No Bluetooth Service Manager")
+            return
 
         service_manager.RegisterApplication(
             self.get_path(),

--- a/tests/lib/cputemp/test_ble_tools.py
+++ b/tests/lib/cputemp/test_ble_tools.py
@@ -1,14 +1,29 @@
 from unittest import TestCase
 from unittest.mock import MagicMock
 from unittest.mock import patch
-
-# Test Cases
 import dbus
+from gatewayconfig.processors.bluetooth_services_processor import \
+    BluetoothServicesProcessor
+from lib.cputemp.advertisement import Advertisement
 from lib.cputemp.bletools import BleTools
 
 
 def return_magic_mock(*args, **kwargs):
     return MagicMock()
+
+
+def system_bus_no_ble_side_effect(*args, **kwargs):
+    def get_object_side_effect(bus_name, object_path):
+        # When there is no BLE adapter, object_path became None
+        # it should raise an exception
+        if not object_path:
+            raise TypeError()
+        return MagicMock()
+
+    mock_dbus = MagicMock()
+    mock_dbus.get_object = MagicMock()
+    mock_dbus.get_object.side_effect = get_object_side_effect
+    return mock_dbus
 
 
 class TestBleTools(TestCase):
@@ -25,6 +40,53 @@ class TestBleTools(TestCase):
         mock_dbus_interface.assert_called()
         bus.get_object.assert_called()
         self.assertEqual(result, None)
+
+    # Test BluetoothServicesProcessor
+    @patch('dbus.SystemBus')
+    @patch('dbus.Interface')
+    def test_service_no_adapter(self, mocked_interface, mocked_system_bus):
+        mocked_system_bus.side_effect = system_bus_no_ble_side_effect
+
+        eth0_mac_address = ""
+        wlan0_mac_address = ""
+        firmware_version = ""
+        ethernet_is_online_filepath = ""
+        shared_state = {}
+
+        try:
+            with self.assertLogs('lib.cputemp', level='DEBUG') as cm:
+                BluetoothServicesProcessor(
+                    eth0_mac_address,
+                    wlan0_mac_address,
+                    firmware_version,
+                    ethernet_is_online_filepath,
+                    shared_state)
+                self.assertIn('ERROR:lib.cputemp.service:'
+                              'Unable to start Bluetooth application: '
+                              'No Bluetooth Adapter',
+                              cm.output)
+        except TypeError:
+            self.fail("Exception raised when no BT adapter")
+
+    # Test Advertisement
+    @patch('dbus.SystemBus')
+    @patch('dbus.Interface')
+    def test_advertise_no_adapter(self, mocked_interface, mocked_system_bus):
+        mocked_system_bus.side_effect = system_bus_no_ble_side_effect
+
+        index = 0
+        advertising_type = "peripheral"
+        try:
+            with self.assertLogs('lib.cputemp',
+                                 level='DEBUG') as cm:
+                ble_advertisement = Advertisement(index, advertising_type)
+                ble_advertisement.register()
+                self.assertIn('ERROR:lib.cputemp.advertisement:'
+                              'Unable to start Advertisement: '
+                              'No Bluetooth adapter.',
+                              cm.output)
+        except TypeError:
+            self.fail("Exception raised when no BT adapter")
 
     @patch('dbus.Interface', side_effect=return_magic_mock)
     def test_find_connection(self, mock_dbus_interface):


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/hm-config/issues/153
- Summary:
As a developer, I should immediately be able to identify when BT is missing and the root cause from glancing at the logs.

**How**
In `cputemp` library's service and advertisement, check if there is a bluetooth adapter.
If there is no bluetooth adapter, a helpful error message should be displayed in the logger and the initialization should continue without raising an exception.

**Screenshots**
![2021-12-13_20-43](https://user-images.githubusercontent.com/91350131/145815415-b6974540-1bc9-4ca2-82ad-a85b598e70ea.png)


**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [x] Thought about variable and method names