### PR TITLE
Bumped hm-pyhelper to 0.13.12 to use the correct RAK button definition

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ colorzero==2.0
 dbus-python==1.2.16
 gpiozero==1.6.2
 h3==3.7.2
-hm-pyhelper==0.13.10
+hm-pyhelper==0.13.12
 nmcli==0.5.0
 protobuf==3.19.3
 pycairo==1.20.1


### PR DESCRIPTION
**Issue**
NebraLtd/hm-pyhelper#125

- Summary:
The RAK button was not working as a gateway-config container advertisement broadcast trigger source.

**How**
* We've mapped to the correct GPIO for RAK devices in hm-pyhelper library. The button would work hm-pyhelper v0.13.12+.
* The important thing is, to make sure the devices would work properly the fleet configuration must include "spi0-1cs" dtoverlay parameter before moving any devices into it. Otherwise the devices would get error on button setup and restart the service on an on indefinitely.

**Checklist**

- [ ] Tests added
- [x] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names