### PR TITLE
 feat: Unable to pair to device a second time without reset #104

### DIFF
--- a/gatewayconfig/bluetooth/characteristics/wifi_connect_characteristic.py
+++ b/gatewayconfig/bluetooth/characteristics/wifi_connect_characteristic.py
@@ -25,7 +25,7 @@ class WifiConnectCharacteristic(Characteristic):
 
         # Credential to connect to a WiFi
         self.wifi_service = ""
-        self.wifi_password = ""
+        self.wifi_password = ""  # nosec B105
 
     def check_wifi_status(self):
         # Check the current wi-fi connection status
@@ -82,7 +82,7 @@ class WifiConnectCharacteristic(Characteristic):
 
             # wipe out the wifi details
             self.wifi_service = ""
-            self.wifi_password = ""
+            self.wifi_password = ""  # nosec B105
 
     def StopNotify(self):
         self.notifying = False

--- a/gatewayconfig/gatewayconfig_app.py
+++ b/gatewayconfig/gatewayconfig_app.py
@@ -134,7 +134,7 @@ class GatewayconfigApp:
 
     def start_bluetooth_advertisement(self):
         LOGGER.debug("Starting bluetooth advertisement")
-        self.shared_state.should_advertise_bluetooth = True
+        self.shared_state.should_advertise_bluetooth_condition_event.set()
 
     def get_button_gpio(self):
         return self.variant_details['BUTTON']

--- a/gatewayconfig/gatewayconfig_shared_state.py
+++ b/gatewayconfig/gatewayconfig_shared_state.py
@@ -1,6 +1,9 @@
 import json
+import threading
+
 from hm_pyhelper.miner_param import get_public_keys_rust
 from hm_pyhelper.logger import get_logger
+
 
 LOGGER = get_logger(__name__)
 PUBLIC_KEY_UNAVAILABLE = 'Unavailable'
@@ -13,13 +16,17 @@ class GatewayconfigSharedState:
     def __init__(self):
         self.wifi_list_cache = []
         self.should_scan_wifi = False
-        self.should_advertise_bluetooth = True
         self.is_advertising_bluetooth = False
         self.are_diagnostics_ok = False
         self.public_key = PUBLIC_KEY_UNAVAILABLE
+        self.should_advertise_bluetooth_condition_event = threading.Event()
+        self.should_advertise_bluetooth_condition_event.set()
 
     def to_s(self):
-        return json.dumps(vars(self))
+        serial_dict = self.__dict__.copy()
+        cv_event = self.should_advertise_bluetooth_condition_event.is_set()
+        serial_dict['should_advertise_bluetooth_condition_event'] = cv_event
+        return json.dumps(serial_dict)
 
     def load_public_key(self):
         """

--- a/gatewayconfig/processors/bluetooth_advertisement_processor.py
+++ b/gatewayconfig/processors/bluetooth_advertisement_processor.py
@@ -1,9 +1,10 @@
-from time import sleep
+import threading
 
 from lib.cputemp.bletools import BleTools
 
 from gatewayconfig.logger import get_logger
-from gatewayconfig.bluetooth.advertisements.bluetooth_connection_advertisement import BluetoothConnectionAdvertisement
+from gatewayconfig.bluetooth.advertisements.bluetooth_connection_advertisement \
+    import BluetoothConnectionAdvertisement
 
 logger = get_logger(__name__)
 ADVERTISEMENT_TYPE = 'peripheral'
@@ -15,16 +16,42 @@ ADVERTISEMENT_OFF_SLEEP_SECONDS = 5
 class BluetoothAdvertisementProcessor:
     def __init__(self, eth0_mac_address, shared_state, variant_details):
         self.shared_state = shared_state
-        self.connection_advertisement = BluetoothConnectionAdvertisement(ADVERTISEMENT_INDEX, eth0_mac_address,
-                                                                         ADVERTISEMENT_TYPE, variant_details)
+        self.connection_advertisement = BluetoothConnectionAdvertisement(
+            ADVERTISEMENT_INDEX, eth0_mac_address,
+            ADVERTISEMENT_TYPE, variant_details)
+        self.stop_advertisement_timer = None
+
+    def start_advertisement(self):
+        logger.debug("Starting Bluetooth advertisement")
+        self.connection_advertisement.register()
+        self.shared_state.is_advertising_bluetooth = True
+        # for security, a start should always result in a scheduled stop
+        self.schedule_stop_advertisement()
+
+    def schedule_stop_advertisement(self, timer_seconds=ADVERTISEMENT_SECONDS):
+        if self.stop_advertisement_timer:
+            logger.debug("cancelling existing stop advertisement timer")
+            self.stop_advertisement_timer.cancel()
+
+        # trigger the time to stop advertisement
+        self.stop_advertisement_timer = threading.Timer(
+            timer_seconds, self.stop_advertisement)
+        self.stop_advertisement_timer.start()
+        logger.debug('scheduled stop advertisement in %s seconds', timer_seconds)
+
+    def stop_advertisement(self):
+        logger.debug("Stopping Bluetooth advertisement")
+        self.connection_advertisement.unregister()
+        self.shared_state.is_advertising_bluetooth = False
+        self.shared_state.should_scan_wifi = False
 
     def run(self):
         logger.debug("Running BluetoothAdvertisementProcessor")
 
         while True:
-            if(self.shared_state.should_advertise_bluetooth is True):
+            advertise_event = self.shared_state.should_advertise_bluetooth_condition_event.wait()
+            if advertise_event:
                 # Prepare to advertise by first scanning wifi and stopping any existing connections
-                self.shared_state.should_advertise_bluetooth = False
                 self.shared_state.should_scan_wifi = True
                 try:
                     BleTools.disconnect_connections()
@@ -33,15 +60,7 @@ class BluetoothAdvertisementProcessor:
                     pass
 
                 # Start advertising
-                self.connection_advertisement.register()
-                logger.debug("Starting Bluetooth advertisement")
-                self.shared_state.is_advertising_bluetooth = True
+                self.start_advertisement()
 
-                # Stop advertising
-                sleep(ADVERTISEMENT_SECONDS)
-                logger.debug("Stopping Bluetooth advertisement")
-                self.connection_advertisement.unregister()
-                self.shared_state.is_advertising_bluetooth = False
-                self.shared_state.should_scan_wifi = False
-            else:
-                sleep(ADVERTISEMENT_OFF_SLEEP_SECONDS)
+                # clear the event
+                self.shared_state.should_advertise_bluetooth_condition_event.clear()

--- a/tests/gatewayconfig/test_gatewayconfig_shared_state.py
+++ b/tests/gatewayconfig/test_gatewayconfig_shared_state.py
@@ -11,24 +11,28 @@ class TestGatewayconfigSha(TestCase):
 
         self.assertEqual(shared_state.wifi_list_cache, [])
         self.assertEqual(shared_state.should_scan_wifi, False)
-        self.assertEqual(shared_state.should_advertise_bluetooth, True)
+        self.assertEqual(shared_state.should_advertise_bluetooth_condition_event.is_set(), True)
         self.assertEqual(shared_state.is_advertising_bluetooth, False)
         self.assertEqual(shared_state.are_diagnostics_ok, False)
 
     def test_to_s(self):
         shared_state = GatewayconfigSharedState()
         self.assertEqual(shared_state.to_s(),
-                         '{"wifi_list_cache": [], "should_scan_wifi": false, "should_advertise_bluetooth": true, '
-                         '"is_advertising_bluetooth": false, "are_diagnostics_ok": false, "public_key": "Unavailable"}'
+                         '{"wifi_list_cache": [], "should_scan_wifi": false, '
+                         '"is_advertising_bluetooth": false, '
+                         '"are_diagnostics_ok": false, "public_key": "Unavailable", '
+                         '"should_advertise_bluetooth_condition_event": true}'
                          )
 
-    @patch('gatewayconfig.gatewayconfig_shared_state.get_public_keys_rust', return_value={'key': 'foo'})
+    @patch('gatewayconfig.gatewayconfig_shared_state.get_public_keys_rust',
+           return_value={'key': 'foo'})
     def test_load_public_key(self, _):
         shared_state = GatewayconfigSharedState()
         shared_state.load_public_key()
         self.assertEqual(shared_state.public_key, 'foo')
 
-    @patch('gatewayconfig.gatewayconfig_shared_state.get_public_keys_rust', return_value={'key': 'foo'})
+    @patch('gatewayconfig.gatewayconfig_shared_state.get_public_keys_rust',
+           return_value={'key': 'foo'})
     def test_load_public_key_dont_override(self, _):
         shared_state = GatewayconfigSharedState()
         shared_state.public_key = 'already_set'


### PR DESCRIPTION
* remove time.sleep for wait
* use threading.Event and threading.Timer to achieve the same

**Long wait between bluetooth advertisement**

- Link: https://github.com/NebraLtd/hm-config/issues/104
- Summary:

**How**
Instead of waiting with time.sleep() in advertisement thread, we use proper thread synchronization primitive threading.Event.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [x] Thought about variable and method names