### PR TITLE
fix: change LED preference order

### DIFF
--- a/gatewayconfig/processors/led_processor.py
+++ b/gatewayconfig/processors/led_processor.py
@@ -18,12 +18,12 @@ class LEDProcessor:
 
         if is_raspberry_pi() or is_rockpi():
             while True:
-                # Blink fast if diagnostics are not OK
-                if(not self.shared_state.are_diagnostics_ok):
-                    self.status_led.blink(0.1, 0.1, 10, False)
                 # Blink slow if advertising bluetooth
-                elif(self.shared_state.is_advertising_bluetooth):
+                if(self.shared_state.is_advertising_bluetooth):
                     self.status_led.blink(1, 1, 1, False)
+                # Blink fast if diagnostics are not OK
+                elif(not self.shared_state.are_diagnostics_ok):
+                    self.status_led.blink(0.1, 0.1, 10, False)
                 # Solid if diagnostics are OK and not advertising
                 else:
                     self.status_led.on()


### PR DESCRIPTION
**Issue**

- Link: #187
- Summary: Bluetooth LED should take precedence over error

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

This changes the Bluetooth LED to take precedence over the error LED

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

Relates-to: #187

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [x] Documentation added
- [x] Thought about variable and method names