### PR TITLE
Bumped hm-pyhelper for Cotx X3 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ colorzero==2.0
 dbus-python==1.2.16
 gpiozero==1.6.2
 h3==3.7.2
-hm-pyhelper==0.13.22
+hm-pyhelper==0.13.23
 nmcli==0.5.0
 protobuf==3.19.3
 pycairo==1.20.1


### PR DESCRIPTION
**Issue**
NebraLtd/helium-miner-software#465

**How**
Bumped hm-pyhelper to add Cotx X3 support

**Checklist**

- [ ] Tests added
- [x] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names