### PR TITLE
feat: Rename hardware definitions #171 (#172)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ colorzero==2.0
 dbus-python==1.2.16
 gpiozero==1.6.2
 h3==3.7.2
-hm-pyhelper==0.13.24
+hm-pyhelper==0.13.32
 nmcli==0.5.0
 protobuf==3.19.3
 pycairo==1.20.1

--- a/tests/gatewayconfig/bluetooth/test_bluetooth_connection_advertisement.py
+++ b/tests/gatewayconfig/bluetooth/test_bluetooth_connection_advertisement.py
@@ -35,7 +35,7 @@ class TestBluetoothConnectionAdvertisement(TestCase):
         )
         self.assertEqual(
             advertisement.local_name,
-            'Nebra Outdoor Hotspot DDE5F6'
+            'Nebra Outdoor Hotspot Gen 1 DDE5F6'
         )
         self.assertEqual(
             advertisement.ad_type,
@@ -59,7 +59,7 @@ class TestBluetoothConnectionAdvertisement(TestCase):
             'org.bluez.LEAdvertisement1': {
                 'Type': 'peripheral',
                 'IncludeTxPower': dbus.Boolean(True),
-                'LocalName': dbus.String('Nebra %s Hotspot %s' % ('Outdoor', 'DDE5F6')),
+                'LocalName': dbus.String('Nebra %s Hotspot %s' % ('Outdoor', 'Gen 1 DDE5F6')),
                 'ServiceUUIDs': dbus.Array([DEFAULT_SERVICE_UUID], signature=dbus.Signature('s'))
             }
         }
@@ -190,7 +190,7 @@ class TestBluetoothConnectionAdvertisement(TestCase):
             advertisement.GetAll(VALID_LE_ADVERTISEMENT_IFACE),
             {
                 'IncludeTxPower': dbus.Boolean(True),
-                'LocalName': dbus.String('Nebra %s Hotspot %s' % ('Outdoor', 'DDE5F6')),
+                'LocalName': dbus.String('Nebra %s Hotspot %s' % ('Outdoor', 'Gen 1 DDE5F6')),
                 'ServiceUUIDs': dbus.Array([DEFAULT_SERVICE_UUID]),
                 'Type': 'peripheral',
             }


### PR DESCRIPTION
* use pyhelper version 0.13.32 that includes variant renames and sentry
  fixes


**[Issue](https://github.com/NebraLtd/hm-pyhelper/issues/171)**

- Link: https://github.com/NebraLtd/hm-pyhelper/issues/171
- Summary: use pyhelper version with new mappings.

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names