### PR TITLE
fix: Diagnostic processor should call diag less frequently #202

### DIFF
--- a/gatewayconfig/bluetooth/characteristics/add_gateway_characteristic.py
+++ b/gatewayconfig/bluetooth/characteristics/add_gateway_characteristic.py
@@ -76,7 +76,7 @@ class AddGatewayCharacteristic(Characteristic):
 
     def ReadValue(self, options):
         logger.debug('Read Add Gateway')
-        if("offset" in options):
+        if "offset" in options:
             cutDownArray = self.notifyValue[int(options["offset"]):]
             return cutDownArray
         else:

--- a/gatewayconfig/bluetooth/characteristics/assert_location_characteristic.py
+++ b/gatewayconfig/bluetooth/characteristics/assert_location_characteristic.py
@@ -83,7 +83,7 @@ class AssertLocationCharacteristic(Characteristic):
 
     def ReadValue(self, options):
         logger.debug('Read Assert Location')
-        if("offset" in options):
+        if "offset" in options:
             cutDownArray = self.notifyValue[int(options["offset"]):]
             return cutDownArray
         else:

--- a/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py
+++ b/gatewayconfig/bluetooth/characteristics/diagnostics_characteristic.py
@@ -115,10 +115,10 @@ class DiagnosticsCharacteristic(Characteristic):
             pass
 
         ip_address = ""
-        if('eth_ip' in locals()):
+        if 'eth_ip' in locals():
             logger.debug("Using ETH IP address %s" % eth_ip)
             ip_address = str(eth_ip)
-        elif('wlan_ip' in locals()):
+        elif 'wlan_ip' in locals():
             ip_address = str(wlan_ip)
             logger.debug("Using WLAN IP address %s" % wlan_ip)
         return ip_address

--- a/gatewayconfig/bluetooth/characteristics/wifi_services_characteristic.py
+++ b/gatewayconfig/bluetooth/characteristics/wifi_services_characteristic.py
@@ -35,11 +35,11 @@ class WifiServicesCharacteristic(Characteristic):
                 ssid_str = str(network.ssid)
                 logger.debug("Inspecting SSID %s" % ssid_str)
 
-                if(is_valid_ssid(ssid_str)):
+                if is_valid_ssid(ssid_str):
                     logger.debug("%s is a valid ssid" % ssid_str)
                     ssid_unknown = ssid_str not in known_wifi_services.services
 
-                    if(ssid_unknown):
+                    if ssid_unknown:
                         logger.debug("%s ssid is unknown" % ssid_str)
                         known_wifi_services.services.append(ssid_str)
 
@@ -49,7 +49,7 @@ class WifiServicesCharacteristic(Characteristic):
             logger.debug("Going to write %s" % val)
             for c in val:
                 value.append(dbus.Byte(c))
-            if("offset" in options):
+            if ("offset" in options):
                 cutDownArray = value[int(options["offset"]):]
                 return cutDownArray
             else:

--- a/gatewayconfig/bluetooth/characteristics/wifi_ssid_characteristic.py
+++ b/gatewayconfig/bluetooth/characteristics/wifi_ssid_characteristic.py
@@ -31,8 +31,8 @@ class WifiSSIDCharacteristic(Characteristic):
         for network in wifi_list_cache:
             ssid_str = str(network.ssid)
 
-            if(is_valid_ssid(ssid_str)):
-                if(network.in_use):
+            if is_valid_ssid(ssid_str):
+                if network.in_use:
                     logger.debug("SSID in use: %s" % ssid_str)
                     active_connection = ssid_str
                 else:

--- a/gatewayconfig/file_loader.py
+++ b/gatewayconfig/file_loader.py
@@ -29,7 +29,7 @@ def read_ethernet_is_online(ethernet_is_online_filepath):
     is_ethernet_online = "false"
 
     ethernet_is_online_carrier_val = open(ethernet_is_online_filepath).readline().strip()
-    if(ethernet_is_online_carrier_val == ETHERNET_IS_ONLINE_CARRIER_VAL):
+    if (ethernet_is_online_carrier_val == ETHERNET_IS_ONLINE_CARRIER_VAL):
         is_ethernet_online = "true"
 
     return is_ethernet_online

--- a/gatewayconfig/gatewayconfig_app.py
+++ b/gatewayconfig/gatewayconfig_app.py
@@ -41,7 +41,7 @@ class GatewayconfigApp:
 
         eth0_mac_address = read_eth0_mac_address(eth0_mac_address_filepath)
         wlan0_mac_address = read_wlan0_mac_address(wlan0_mac_address_filepath)
-        LOGGER.debug("Read eth0 mac address %s and wlan0 %s" % (eth0_mac_address, wlan0_mac_address))
+        LOGGER.debug("Read eth0 mac address {} and wlan0 {}".format(eth0_mac_address, wlan0_mac_address))
         self.shared_state.load_public_key()
 
         self.bluetooth_services_processor = BluetoothServicesProcessor(
@@ -144,6 +144,7 @@ class GatewayconfigApp:
     def start_bluetooth_advertisement(self):
         LOGGER.debug("Starting bluetooth advertisement")
         self.shared_state.should_advertise_bluetooth_condition_event.set()
+        self.shared_state.run_fast_diagnostic_condition_event.set()
 
     def get_button_gpio(self):
         return self.variant_details['BUTTON']

--- a/gatewayconfig/gatewayconfig_shared_state.py
+++ b/gatewayconfig/gatewayconfig_shared_state.py
@@ -20,11 +20,17 @@ class GatewayconfigSharedState:
         self.public_key = PUBLIC_KEY_UNAVAILABLE
         self.should_advertise_bluetooth_condition_event = threading.Event()
         self.should_advertise_bluetooth_condition_event.set()
+        # this is used when user is interacting with bluetooth. he might be trying to fix a
+        # diag error. When bluetooth is triggered, fast diagnostics should also be triggered.
+        self.run_fast_diagnostic_condition_event = threading.Event()
+        self.run_fast_diagnostic_condition_event.set()
 
     def to_s(self):
         serial_dict = self.__dict__.copy()
         cv_event = self.should_advertise_bluetooth_condition_event.is_set()
         serial_dict['should_advertise_bluetooth_condition_event'] = cv_event
+        diag_cv_event = self.run_fast_diagnostic_condition_event.is_set()
+        serial_dict['run_fast_diagnostic_condition_event'] = diag_cv_event
         return json.dumps(serial_dict)
 
     def load_public_key(self):

--- a/gatewayconfig/processors/diagnostics_processor.py
+++ b/gatewayconfig/processors/diagnostics_processor.py
@@ -1,25 +1,59 @@
 import json
 import requests
-from time import sleep
+import threading
 
 from gatewayconfig.logger import get_logger
 from gatewayconfig.gatewayconfig_shared_state import GatewayconfigSharedState
 
 logger = get_logger(__name__)
-DIAGNOSTICS_REFRESH_SECONDS = 60
+DIAGNOSTICS_REFRESH_SECONDS_SLOW = 3600
+DIAGNOSTICS_REFRESH_SECONDS_FAST = 60
+FAST_DIAGNOSTIC_TIMEOUT = 1800
 
 
 class DiagnosticsProcessor:
     def __init__(self, diagnostics_json_url, shared_state: GatewayconfigSharedState):
         self.shared_state = shared_state
         self.diagnostics_json_url = diagnostics_json_url
+        self.fast_diagnostics = False
+
+    def get_refresh_interval(self) -> int:
+        if self.fast_diagnostics or not self.shared_state.are_diagnostics_ok:
+            return DIAGNOSTICS_REFRESH_SECONDS_FAST
+        return DIAGNOSTICS_REFRESH_SECONDS_SLOW
+
+    def schedule_stop_fast_diagnostics(self, timer_seconds=FAST_DIAGNOSTIC_TIMEOUT):
+        if self.fast_diagnostics_timer:
+            logger.debug("cancelling existing stop fast diagnostic timer")
+            self.fast_diagnostics_timer.cancel()
+
+        # trigger the time to stop advertisement
+        self.fast_diagnostics_timer = threading.Timer(timer_seconds,
+                                                      self.stop_fast_diagnostics)
+        self.fast_diagnostics_timer.start()
+        logger.debug('scheduled stop fast diagnostics in %s seconds', timer_seconds)
+
+    def stop_fast_diagnostics(self):
+        logger.debug("Stopping fast diagnostics refresh.")
+        self.fast_diagnostics = False
 
     def run(self):
         while True:
+            # it will be set to true when someone sets trigger fast_diagnostic event
+            # if timeout expires it will be to set to false
+            event_state = self.shared_state.run_fast_diagnostic_condition_event.wait(
+                timeout=self.get_refresh_interval()
+                )
+            if event_state:
+                logger.debug(f"Fast diagnostics refresh triggered. "
+                             f"Will run for {DIAGNOSTICS_REFRESH_SECONDS_FAST} seconds")
+                self.shared_state.run_fast_diagnostic_condition_event.clear()
+                self.fast_diagnostics = True
+                self.schedule_stop_fast_diagnostics()
+
             logger.debug("Running DiagnosticsProcessor")
             self.read_diagnostics()
             logger.debug(self.shared_state)
-            sleep(DIAGNOSTICS_REFRESH_SECONDS)
 
     def read_diagnostics_and_get_ok(self):
         logger.debug("Reading diagnostics from %s" % self.diagnostics_json_url)

--- a/gatewayconfig/processors/led_processor.py
+++ b/gatewayconfig/processors/led_processor.py
@@ -19,10 +19,10 @@ class LEDProcessor:
         if is_raspberry_pi() or is_rockpi():
             while True:
                 # Blink slow if advertising bluetooth
-                if(self.shared_state.is_advertising_bluetooth):
+                if self.shared_state.is_advertising_bluetooth:
                     self.status_led.blink(1, 1, 1, False)
                 # Blink fast if diagnostics are not OK
-                elif(not self.shared_state.are_diagnostics_ok):
+                elif not self.shared_state.are_diagnostics_ok:
                     self.status_led.blink(0.1, 0.1, 10, False)
                 # Solid if diagnostics are OK and not advertising
                 else:

--- a/tests/gatewayconfig/test_gatewayconfig_shared_state.py
+++ b/tests/gatewayconfig/test_gatewayconfig_shared_state.py
@@ -11,6 +11,7 @@ class TestGatewayconfigSha(TestCase):
 
         self.assertEqual(shared_state.should_scan_wifi, False)
         self.assertEqual(shared_state.should_advertise_bluetooth_condition_event.is_set(), True)
+        self.assertEqual(shared_state.run_fast_diagnostic_condition_event.is_set(), True)
         self.assertEqual(shared_state.is_advertising_bluetooth, False)
         self.assertEqual(shared_state.are_diagnostics_ok, False)
 
@@ -20,7 +21,8 @@ class TestGatewayconfigSha(TestCase):
                          '{"should_scan_wifi": false, '
                          '"is_advertising_bluetooth": false, '
                          '"are_diagnostics_ok": false, "public_key": "Unavailable", '
-                         '"should_advertise_bluetooth_condition_event": true}'
+                         '"should_advertise_bluetooth_condition_event": true, '
+                         '"run_fast_diagnostic_condition_event": true}'
                          )
 
     @patch('gatewayconfig.gatewayconfig_shared_state.get_public_keys_rust',


### PR DESCRIPTION
* added slow refersh in case everything is ok.

**[Issue](https://github.com/NebraLtd/hm-config/issues/202)**

- Link: https://github.com/NebraLtd/hm-config/issues/202
- Summary: don't refresh diagnostics unnecessarily.

**How**
Now config queries diagnostics at two speeds. Initially at boot or bluetooth active cases it queries at 1 minute interval for half an hour. Making it truely ondemand was possible by making diag_ok variable in shared state a method call that fetches the diag. but I was worried that it might break some led patterns especially if the user is setting up his device.

After that it queries at 1 hour intervals.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names