### PR TITLE
Fixed new nmcli version incompatibilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ dbus-python==1.3.2
 gpiozero==1.6.2
 h3==3.7.6
 hm-pyhelper==0.13.45
-nmcli==0.5.0
+nmcli==1.1.2
 protobuf==3.20.3
 pycairo==1.23.0
 requests==2.28.1

--- a/tests/gatewayconfig/bluetooth/test_wifi_services_characteristic.py
+++ b/tests/gatewayconfig/bluetooth/test_wifi_services_characteristic.py
@@ -17,10 +17,10 @@ class TestWifiServicesCharacteristic(TestCase):
     @patch('lib.nmcli_custom.device.wifi_rescan')
     @patch('lib.nmcli_custom.device.wifi',
            return_value=[
-               DeviceWifi(in_use=False, ssid='TP-LINK', mode='Infra', chan=5, rate=54, signal=100,
-                          security='WPA1'),
-               DeviceWifi(in_use=True, ssid='PHICOMM', mode='Infra', chan=1, rate=44, signal=96,
-                          security='WPA2')
+               DeviceWifi(in_use=False, ssid='TP-LINK', bssid='001122334455', mode='Infra',
+                          chan=5, freq=2432, rate=54, signal=100, security='WPA1'),
+               DeviceWifi(in_use=True, ssid='PHICOMM', bssid='001122334456', mode='Infra',
+                          chan=1, freq=2412, rate=44, signal=96, security='WPA2')
            ])
     def test_ReadValue(self, mock1, mock2):
         characteristic = WifiServicesCharacteristic(self.service, GatewayconfigSharedState())

--- a/tests/gatewayconfig/bluetooth/test_wifi_ssid_characteristic.py
+++ b/tests/gatewayconfig/bluetooth/test_wifi_ssid_characteristic.py
@@ -16,10 +16,10 @@ class TestWifiSSIDCharacteristic(TestCase):
     @patch('lib.nmcli_custom.device.wifi_rescan')
     @patch('lib.nmcli_custom.device.wifi',
            return_value=[
-               DeviceWifi(in_use=False, ssid='TP-LINK', mode='Infra', chan=5, rate=54, signal=100,
-                          security='WPA1'),
-               DeviceWifi(in_use=True, ssid='PHICOMM', mode='Infra', chan=1, rate=44, signal=96,
-                          security='WPA2')
+               DeviceWifi(in_use=False, ssid='TP-LINK', bssid='001122334455', mode='Infra',
+                          chan=5, freq=2432, rate=54, signal=100, security='WPA1'),
+               DeviceWifi(in_use=True, ssid='PHICOMM', bssid='001122334456', mode='Infra',
+                          chan=1, freq=2412, rate=44, signal=96, security='WPA2')
            ])
     def test_ReadValue(self, mock1, mock2):
         characteristic = WifiSSIDCharacteristic(self.service, GatewayconfigSharedState())


### PR DESCRIPTION
**Issue**
Fixes #217 

- Summary:

`nmcli` versions starting from 0.6.0 needs `bssid` and `freq` parameter for a `DeviceWiFi` object construction. Added those and bumped `nmcli` to the newest version.

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [x] Thought about variable and method names